### PR TITLE
chore: update GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/cms-deploy.yml
+++ b/.github/workflows/cms-deploy.yml
@@ -7,15 +7,17 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       contents: read
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,13 +7,15 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       contents: read
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,14 +7,16 @@ on:
 jobs:
   preview:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       contents: read
       deployments: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -41,7 +43,7 @@ jobs:
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment preview URL on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const url = '${{ steps.deploy.outputs.pages-deployment-alias-url }}';


### PR DESCRIPTION
## Summary

- Update `actions/checkout` v4 → v6 (Node 24 support)
- Update `actions/setup-node` v4 → v6 (Node 24 support)
- Update `actions/github-script` v7 → v8 (Node 24 support)
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` job-level env var to all workflows for `cloudflare/wrangler-action@v3` (still on node20 internally, no v4 available)

Resolves Node.js 20 deprecation warnings in CI runs.

## Files changed

- `.github/workflows/preview.yml`
- `.github/workflows/deploy.yml`
- `.github/workflows/cms-deploy.yml`