### PR TITLE
chore: add Dependabot for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    groups:
+      astro:
+        patterns:
+          - "astro"
+          - "@astrojs/*"
+      sanity:
+        patterns:
+          - "@sanity/*"
+          - "sanity"
+      lint:
+        patterns:
+          - "eslint*"
+          - "@eslint/*"
+          - "prettier*"
+          - "typescript-eslint"
+          - "eslint-*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,19 +12,19 @@ updates:
     groups:
       astro:
         patterns:
-          - "astro"
-          - "@astrojs/*"
+          - 'astro'
+          - '@astrojs/*'
       sanity:
         patterns:
-          - "@sanity/*"
-          - "sanity"
+          - '@sanity/*'
+          - 'sanity'
       lint:
         patterns:
-          - "eslint*"
-          - "@eslint/*"
-          - "prettier*"
-          - "typescript-eslint"
-          - "eslint-*"
+          - 'eslint*'
+          - '@eslint/*'
+          - 'prettier*'
+          - 'typescript-eslint'
+          - 'eslint-*'
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` for automated dependency updates
- **npm ecosystem**: weekly checks, groups related packages (Astro, Sanity, lint tooling)
- **GitHub Actions ecosystem**: weekly checks for action version updates
- Both run Mondays with sensible PR limits (10 for npm, 5 for actions)

## Dependency groups

Reduces PR noise by grouping:
- `astro` + `@astrojs/*`
- `@sanity/*` + `sanity`
- `eslint*` + `prettier*` + `typescript-eslint`