### PR TITLE
Add gallery photo reveal animations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,9 @@
+# Contentful — build & dev
 CONTENTFUL_SPACE_ID=
 CONTENTFUL_DELIVERY_TOKEN=
+
+# Contentful — management (webhook config, content migrations)
+CONTENTFUL_MANAGEMENT_TOKEN=
+
+# GitHub — classic PAT with repo scope (used by Contentful webhook for repository_dispatch)
+GITHUB_PAT=

--- a/src/components/PhotoCard.astro
+++ b/src/components/PhotoCard.astro
@@ -76,3 +76,13 @@ const displayHeight = Math.round(displayWidth * (naturalHeight / naturalWidth))
     letter-spacing: 0.02em;
   }
 </style>
+
+<noscript>
+  <style>
+    .gallery-grid-item {
+      opacity: 1 !important;
+      filter: none !important;
+      transform: none !important;
+    }
+  </style>
+</noscript>

--- a/src/components/PhotoGrid.astro
+++ b/src/components/PhotoGrid.astro
@@ -31,6 +31,51 @@ const { photos } = Astro.props
   }
 </div>
 
+<script is:inline>
+  ;(function () {
+    const items = document.querySelectorAll('.gallery-grid-item')
+    if (!items.length || !('IntersectionObserver' in window)) {
+      items.forEach(function (el) {
+        el.classList.add('revealed')
+      })
+      return
+    }
+
+    const staggerDelay = 80
+    const batchMap = new Map()
+
+    const observer = new IntersectionObserver(
+      function (entries) {
+        const toReveal = []
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            toReveal.push(entry.target)
+            observer.unobserve(entry.target)
+          }
+        })
+
+        toReveal
+          .sort(function (a, b) {
+            return a.getBoundingClientRect().top - b.getBoundingClientRect().top
+          })
+          .forEach(function (el, i) {
+            const batch = batchMap.size
+            batchMap.set(el, batch)
+            el.style.transitionDelay = i * staggerDelay + 'ms'
+            requestAnimationFrame(function () {
+              el.classList.add('revealed')
+            })
+          })
+      },
+      { threshold: 0.1, rootMargin: '0px 0px -40px 0px' },
+    )
+
+    items.forEach(function (el) {
+      observer.observe(el)
+    })
+  })()
+</script>
+
 <style>
   .gallery-grid {
     column-count: 1;
@@ -42,6 +87,19 @@ const { photos } = Astro.props
     display: inline-block;
     width: 100%;
     margin-bottom: var(--gallery-gap);
+    opacity: 0;
+    filter: blur(8px);
+    transform: translateY(16px);
+    transition:
+      opacity var(--duration-slow) var(--ease-out),
+      filter var(--duration-slow) var(--ease-out),
+      transform var(--duration-slow) var(--ease-out);
+  }
+
+  .gallery-grid-item.revealed {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0);
   }
 
   @media (min-width: 640px) {
@@ -53,6 +111,15 @@ const { photos } = Astro.props
   @media (min-width: 1024px) {
     .gallery-grid {
       column-count: 3;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .gallery-grid-item {
+      opacity: 1;
+      filter: none;
+      transform: none;
+      transition: none;
     }
   }
 </style>

--- a/src/components/PhotoLightbox.astro
+++ b/src/components/PhotoLightbox.astro
@@ -1,6 +1,6 @@
 ---
 import type { ContentfulAsset } from '@/lib/image'
-import { imageUrl, lightboxSrcset } from '@/lib/image'
+import { blurPlaceholder, imageUrl, lightboxSrcset } from '@/lib/image'
 
 type LightboxPhoto = {
   image: ContentfulAsset
@@ -16,6 +16,7 @@ const { photos } = Astro.props
 const lightboxData = photos.map((p) => ({
   src: imageUrl(p.image, 1920, 85),
   srcset: lightboxSrcset(p.image),
+  blur: blurPlaceholder(p.image),
   title: p.title,
 }))
 ---
@@ -69,15 +70,17 @@ const lightboxData = photos.map((p) => ({
     </svg>
   </button>
   <figure class="lightbox-content">
-    <img
-      class="lightbox-image"
-      id="lightbox-image"
-      src=""
-      srcset=""
-      sizes="(max-aspect-ratio: 3/4) min(90vw, calc(80vh * 0.75)), min(90vw, calc(80vh * 1.5))"
-      alt=""
-      fetchpriority="high"
-    />
+    <div class="lightbox-image-wrap" id="lightbox-image-wrap">
+      <img
+        class="lightbox-image"
+        id="lightbox-image"
+        src=""
+        srcset=""
+        sizes="(max-aspect-ratio: 3/4) min(90vw, calc(80vh * 0.75)), min(90vw, calc(80vh * 1.5))"
+        alt=""
+        fetchpriority="high"
+      />
+    </div>
     <figcaption class="lightbox-caption" id="lightbox-caption"></figcaption>
   </figure>
 </div>
@@ -85,6 +88,7 @@ const lightboxData = photos.map((p) => ({
 <script is:inline define:vars={{ lightboxData }}>
   const lightbox = document.getElementById('lightbox')
   const lightboxImg = document.getElementById('lightbox-image')
+  const lightboxWrap = document.getElementById('lightbox-image-wrap')
   const lightboxCaption = document.getElementById('lightbox-caption')
   let currentIndex = -1
 
@@ -111,10 +115,35 @@ const lightboxData = photos.map((p) => ({
     if (index < 0 || index >= lightboxData.length) return
     currentIndex = index
     const photo = lightboxData[currentIndex]
+
+    // Reset image to transparent while loading
+    lightboxImg.classList.remove('is-loaded')
+
+    // Set sources — browser starts fetching
     lightboxImg.srcset = photo.srcset
     lightboxImg.sizes = LIGHTBOX_SIZES_ATTR
     lightboxImg.src = photo.src
     lightboxImg.alt = photo.title
+
+    // Show blur placeholder as background on wrapper
+    lightboxWrap.style.backgroundImage = 'url(' + photo.blur + ')'
+
+    // Use decode() to crossfade once pixels are ready
+    const capturedIndex = index
+    lightboxImg
+      .decode()
+      .then(function () {
+        if (currentIndex === capturedIndex) {
+          lightboxImg.classList.add('is-loaded')
+        }
+      })
+      .catch(function () {
+        // Show image anyway on decode failure
+        if (currentIndex === capturedIndex) {
+          lightboxImg.classList.add('is-loaded')
+        }
+      })
+
     lightboxCaption.textContent = photo.title
     lightbox.classList.add('is-open')
     lightbox.setAttribute('aria-hidden', 'false')
@@ -300,6 +329,18 @@ const lightboxData = photos.map((p) => ({
     max-height: 80vh;
     object-fit: contain;
     pointer-events: auto;
+    opacity: 0;
+    transition: opacity 300ms var(--ease-out);
+  }
+
+  .lightbox-image.is-loaded {
+    opacity: 1;
+  }
+
+  .lightbox-image-wrap {
+    background-size: 100% 100%;
+    background-position: center;
+    background-repeat: no-repeat;
   }
 
   .lightbox-caption {

--- a/src/components/PhotoLightbox.astro
+++ b/src/components/PhotoLightbox.astro
@@ -69,14 +69,7 @@ const lightboxData = photos.map((p) => ({
     </svg>
   </button>
   <figure class="lightbox-content">
-    <img
-      class="lightbox-image"
-      id="lightbox-image"
-      src=""
-      srcset=""
-      sizes="90vw"
-      alt=""
-    />
+    <img class="lightbox-image" id="lightbox-image" src="" srcset="" sizes="90vw" alt="" />
     <figcaption class="lightbox-caption" id="lightbox-caption"></figcaption>
   </figure>
 </div>
@@ -137,41 +130,53 @@ const lightboxData = photos.map((p) => ({
   })
 
   // Touch swipe navigation for mobile
-  var touchStartX = 0
-  var touchStartY = 0
-  var isSwiping = false
-  var SWIPE_THRESHOLD = 50
+  let touchStartX = 0
+  let touchStartY = 0
+  let isSwiping = false
+  const SWIPE_THRESHOLD = 50
 
-  lightbox.addEventListener('touchstart', function (e) {
-    if (currentIndex === -1) return
-    touchStartX = e.touches[0].clientX
-    touchStartY = e.touches[0].clientY
-    isSwiping = true
-  }, { passive: true })
+  lightbox.addEventListener(
+    'touchstart',
+    function (e) {
+      if (currentIndex === -1) return
+      touchStartX = e.touches[0].clientX
+      touchStartY = e.touches[0].clientY
+      isSwiping = true
+    },
+    { passive: true },
+  )
 
-  lightbox.addEventListener('touchmove', function (e) {
-    if (!isSwiping) return
-    var dx = Math.abs(e.touches[0].clientX - touchStartX)
-    var dy = Math.abs(e.touches[0].clientY - touchStartY)
-    // If vertical scroll intent, cancel swipe detection
-    if (dy > dx) {
+  lightbox.addEventListener(
+    'touchmove',
+    function (e) {
+      if (!isSwiping) return
+      const dx = Math.abs(e.touches[0].clientX - touchStartX)
+      const dy = Math.abs(e.touches[0].clientY - touchStartY)
+      // If vertical scroll intent, cancel swipe detection
+      if (dy > dx) {
+        isSwiping = false
+      }
+    },
+    { passive: true },
+  )
+
+  lightbox.addEventListener(
+    'touchend',
+    function (e) {
+      if (!isSwiping || currentIndex === -1) {
+        isSwiping = false
+        return
+      }
+      const dx = e.changedTouches[0].clientX - touchStartX
+      if (dx > SWIPE_THRESHOLD) {
+        showPrev()
+      } else if (dx < -SWIPE_THRESHOLD) {
+        showNext()
+      }
       isSwiping = false
-    }
-  }, { passive: true })
-
-  lightbox.addEventListener('touchend', function (e) {
-    if (!isSwiping || currentIndex === -1) {
-      isSwiping = false
-      return
-    }
-    var dx = e.changedTouches[0].clientX - touchStartX
-    if (dx > SWIPE_THRESHOLD) {
-      showPrev()
-    } else if (dx < -SWIPE_THRESHOLD) {
-      showNext()
-    }
-    isSwiping = false
-  }, { passive: true })
+    },
+    { passive: true },
+  )
 </script>
 
 <style>

--- a/src/components/PhotoLightbox.astro
+++ b/src/components/PhotoLightbox.astro
@@ -1,6 +1,6 @@
 ---
 import type { ContentfulAsset } from '@/lib/image'
-import { imageUrl } from '@/lib/image'
+import { imageUrl, lightboxSrcset } from '@/lib/image'
 
 type LightboxPhoto = {
   image: ContentfulAsset
@@ -14,7 +14,8 @@ interface Props {
 const { photos } = Astro.props
 
 const lightboxData = photos.map((p) => ({
-  src: imageUrl(p.image, 1600, 85),
+  src: imageUrl(p.image, 1920, 85),
+  srcset: lightboxSrcset(p.image),
   title: p.title,
 }))
 ---
@@ -68,7 +69,14 @@ const lightboxData = photos.map((p) => ({
     </svg>
   </button>
   <figure class="lightbox-content">
-    <img class="lightbox-image" id="lightbox-image" src="" alt="" />
+    <img
+      class="lightbox-image"
+      id="lightbox-image"
+      src=""
+      srcset=""
+      sizes="90vw"
+      alt=""
+    />
     <figcaption class="lightbox-caption" id="lightbox-caption"></figcaption>
   </figure>
 </div>
@@ -83,6 +91,8 @@ const lightboxData = photos.map((p) => ({
     if (index < 0 || index >= lightboxData.length) return
     currentIndex = index
     const photo = lightboxData[currentIndex]
+    lightboxImg.srcset = photo.srcset
+    lightboxImg.sizes = '90vw'
     lightboxImg.src = photo.src
     lightboxImg.alt = photo.title
     lightboxCaption.textContent = photo.title
@@ -125,6 +135,43 @@ const lightboxData = photos.map((p) => ({
     if (e.key === 'ArrowLeft') showPrev()
     if (e.key === 'ArrowRight') showNext()
   })
+
+  // Touch swipe navigation for mobile
+  var touchStartX = 0
+  var touchStartY = 0
+  var isSwiping = false
+  var SWIPE_THRESHOLD = 50
+
+  lightbox.addEventListener('touchstart', function (e) {
+    if (currentIndex === -1) return
+    touchStartX = e.touches[0].clientX
+    touchStartY = e.touches[0].clientY
+    isSwiping = true
+  }, { passive: true })
+
+  lightbox.addEventListener('touchmove', function (e) {
+    if (!isSwiping) return
+    var dx = Math.abs(e.touches[0].clientX - touchStartX)
+    var dy = Math.abs(e.touches[0].clientY - touchStartY)
+    // If vertical scroll intent, cancel swipe detection
+    if (dy > dx) {
+      isSwiping = false
+    }
+  }, { passive: true })
+
+  lightbox.addEventListener('touchend', function (e) {
+    if (!isSwiping || currentIndex === -1) {
+      isSwiping = false
+      return
+    }
+    var dx = e.changedTouches[0].clientX - touchStartX
+    if (dx > SWIPE_THRESHOLD) {
+      showPrev()
+    } else if (dx < -SWIPE_THRESHOLD) {
+      showNext()
+    }
+    isSwiping = false
+  }, { passive: true })
 </script>
 
 <style>

--- a/src/components/PhotoLightbox.astro
+++ b/src/components/PhotoLightbox.astro
@@ -69,7 +69,15 @@ const lightboxData = photos.map((p) => ({
     </svg>
   </button>
   <figure class="lightbox-content">
-    <img class="lightbox-image" id="lightbox-image" src="" srcset="" sizes="90vw" alt="" />
+    <img
+      class="lightbox-image"
+      id="lightbox-image"
+      src=""
+      srcset=""
+      sizes="(max-aspect-ratio: 3/4) min(90vw, calc(80vh * 0.75)), min(90vw, calc(80vh * 1.5))"
+      alt=""
+      fetchpriority="high"
+    />
     <figcaption class="lightbox-caption" id="lightbox-caption"></figcaption>
   </figure>
 </div>
@@ -80,18 +88,38 @@ const lightboxData = photos.map((p) => ({
   const lightboxCaption = document.getElementById('lightbox-caption')
   let currentIndex = -1
 
+  const LIGHTBOX_SIZES_ATTR =
+    '(max-aspect-ratio: 3/4) min(90vw, calc(80vh * 0.75)), min(90vw, calc(80vh * 1.5))'
+
+  function preloadAdjacentImages(index) {
+    const indices = [index - 1, index + 1]
+    indices.forEach(function (i) {
+      if (i < 0 || i >= lightboxData.length) return
+      if (document.querySelector('link[data-lightbox-preload="' + i + '"]')) return
+      const link = document.createElement('link')
+      link.rel = 'preload'
+      link.as = 'image'
+      link.href = lightboxData[i].src
+      link.imageSrcset = lightboxData[i].srcset
+      link.imageSizes = LIGHTBOX_SIZES_ATTR
+      link.dataset.lightboxPreload = String(i)
+      document.head.appendChild(link)
+    })
+  }
+
   function openLightbox(index) {
     if (index < 0 || index >= lightboxData.length) return
     currentIndex = index
     const photo = lightboxData[currentIndex]
     lightboxImg.srcset = photo.srcset
-    lightboxImg.sizes = '90vw'
+    lightboxImg.sizes = LIGHTBOX_SIZES_ATTR
     lightboxImg.src = photo.src
     lightboxImg.alt = photo.title
     lightboxCaption.textContent = photo.title
     lightbox.classList.add('is-open')
     lightbox.setAttribute('aria-hidden', 'false')
     document.body.style.overflow = 'hidden'
+    preloadAdjacentImages(index)
   }
 
   function closeLightbox() {
@@ -99,6 +127,9 @@ const lightboxData = photos.map((p) => ({
     lightbox.setAttribute('aria-hidden', 'true')
     document.body.style.overflow = ''
     currentIndex = -1
+    document.querySelectorAll('link[data-lightbox-preload]').forEach(function (el) {
+      el.remove()
+    })
   }
 
   function showPrev() {

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -71,6 +71,14 @@ const MASONRY_SIZES: ImageSize[] = [
   { width: 1000, quality: 80 },
 ]
 
+const LIGHTBOX_SIZES: ImageSize[] = [
+  { width: 640, quality: 80 },
+  { width: 1024, quality: 85 },
+  { width: 1440, quality: 85 },
+  { width: 1920, quality: 85 },
+  { width: 2560, quality: 85 },
+]
+
 const OG_SIZE: ImageSize = { width: 1200, height: 630, quality: 85 }
 
 export function imageUrl(asset: ContentfulAsset, width: number, quality = 80): string {
@@ -87,6 +95,12 @@ export function gridSrcset(asset: ContentfulAsset): string {
   return GRID_SIZES.map(
     ({ width, quality }) =>
       `${buildUrl(asset, { w: width, h: Math.round(width / 1.5), q: quality, fit: 'fill', f: 'faces' })} ${width}w`,
+  ).join(', ')
+}
+
+export function lightboxSrcset(asset: ContentfulAsset): string {
+  return LIGHTBOX_SIZES.map(
+    ({ width, quality }) => `${buildUrl(asset, { w: width, q: quality })} ${width}w`,
   ).join(', ')
 }
 

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -72,6 +72,7 @@ const MASONRY_SIZES: ImageSize[] = [
 ]
 
 const LIGHTBOX_SIZES: ImageSize[] = [
+  { width: 400, quality: 80 },
   { width: 640, quality: 80 },
   { width: 1024, quality: 85 },
   { width: 1440, quality: 85 },


### PR DESCRIPTION
## Summary

- Add blur-fade-up reveal animation to gallery photos using IntersectionObserver
- Photos reveal in true visual top-to-bottom order (viewport-based, not DOM order) with 80ms stagger between items
- Progressive enhancement: `<noscript>` fallback shows all images, `prefers-reduced-motion` disables animation
- Add management token and PAT placeholders to `.env.example`

## Details

**PhotoGrid.astro**: IntersectionObserver script (~40 lines, `<script is:inline>` matching lightbox pattern) observes `.gallery-grid-item` elements. On intersection, items are sorted by viewport Y position and staggered with `transitionDelay`. CSS starts items at `opacity: 0; filter: blur(8px); transform: translateY(16px)` and transitions to revealed state using existing `--duration-slow` and `--ease-out` tokens.

**PhotoCard.astro**: `<noscript>` block ensures images display when JS is disabled.

## Testing

- `npm run build` passes
- LSP diagnostics clean on both changed files