### PR TITLE
Phase 9: Performance audit and image loading improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -253,15 +253,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/types": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
@@ -326,41 +317,24 @@
       "license": "MPL-2.0"
     },
     "node_modules/@contentful/rich-text-html-renderer": {
-      "version": "17.1.6",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-html-renderer/-/rich-text-html-renderer-17.1.6.tgz",
-      "integrity": "sha512-q1tdl9sdP3VYF/8GmQIkSLq5kcFSJGKzWpXO39Nyw4AXrT70gT/pC4wIFUjb75jf67uga3OGz7JBzdKy4NtkNA==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-html-renderer/-/rich-text-html-renderer-17.2.2.tgz",
+      "integrity": "sha512-Ps5SGrlrgvzJw7n7rawj6RLlv7eZnpDcGrnr8G+0FyOVsvh8y9azwyuQ4MVshgZUUJ02Z2Tc07YiTFYRFCFrlg==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/rich-text-types": "^17.2.5",
-        "escape-html": "^1.0.3"
+        "@contentful/rich-text-types": "^17.2.7"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@contentful/rich-text-types": {
-      "version": "17.2.5",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.2.5.tgz",
-      "integrity": "sha512-EA5vTfROZePoPmSlqLVd+luL/ev8CjnI20y6vWFVPlLRxQbv4XytXRzatydPE63CqfsPylF7NCn2z8rTLhnWfg==",
-      "license": "MIT",
-      "dependencies": {
-        "@lingui/core": "^5.4.1",
-        "is-plain-obj": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@contentful/rich-text-types/node_modules/is-plain-obj": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "version": "17.2.7",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.2.7.tgz",
+      "integrity": "sha512-aIdozk8vk5gsYcallOrwEiL6+GSlMXZorDOmiVELfpbVaXMJPJPlf2CBw3LUzviAqCw0UPQcKHHCwG7SdY7u5w==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@emmetio/abbreviation": {
@@ -1503,53 +1477,6 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
-    "node_modules/@lingui/core": {
-      "version": "5.9.4",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-5.9.4.tgz",
-      "integrity": "sha512-MsYYc8ue/w1C8bgAbC3h4cNik64bqZ6xGxMjsVdoGQBUe+b/ij+rOEiuJXbwvlo4GXBsvsan7EzeH7sx11IsYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "5.9.4"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@lingui/babel-plugin-lingui-macro": "5.9.4",
-        "babel-plugin-macros": "2 || 3"
-      },
-      "peerDependenciesMeta": {
-        "@lingui/babel-plugin-lingui-macro": {
-          "optional": true
-        },
-        "babel-plugin-macros": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@lingui/message-utils": {
-      "version": "5.9.4",
-      "resolved": "https://registry.npmjs.org/@lingui/message-utils/-/message-utils-5.9.4.tgz",
-      "integrity": "sha512-YzAVzILdsqdUqwHmryl7rfwZXRHYs6QY2wPLH5gxrV7wlieiCaskaKPeSk2SuN/gmC8im1GDrQHcwgKapFU3Sg==",
-      "license": "MIT",
-      "dependencies": {
-        "@messageformat/parser": "^5.0.0",
-        "js-sha256": "^0.10.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@messageformat/parser": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@messageformat/parser/-/parser-5.1.1.tgz",
-      "integrity": "sha512-3p0YRGCcTUCYvBKLIxtDDyrJ0YijGIwrTRu1DT8gIviIDZru8H23+FkY6MJBzM1n9n20CiM4VeDYuBsrrwnLjg==",
-      "license": "MIT",
-      "dependencies": {
-        "moo": "^0.5.1"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2604,9 +2531,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.3.tgz",
-      "integrity": "sha512-FUKbBYOdYYrRNZwDd9I5CVSfR6Nj9aZeNzcjcvh1FgHwR0uXawkYFR3HiGxmdmAB2m8fs0iIkDdsiUfwGeO8qA==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.5.tgz",
+      "integrity": "sha512-AJVw/JlssxUCBFi3Hp4djL8Pt7wUQqStBBawCd8cNGBBM2lBzp/rXGguzt4OcMfW+86fs0hpFwMyopHM2r6d3g==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^3.0.1",
@@ -2625,7 +2552,6 @@
         "cookie": "^1.1.1",
         "devalue": "^5.6.3",
         "diff": "^8.0.3",
-        "dlv": "^1.1.3",
         "dset": "^3.1.4",
         "es-module-lexer": "^2.0.0",
         "esbuild": "^0.27.3",
@@ -2795,9 +2721,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -3610,12 +3536,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
@@ -4742,12 +4662,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/js-sha256": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.10.1.tgz",
-      "integrity": "sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw==",
-      "license": "MIT"
-    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -5747,12 +5661,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/moo": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.3.tgz",
-      "integrity": "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
@@ -7494,9 +7402,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,17 @@
+# Immutable hashed assets (Astro output)
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Fonts — long-lived, versioned by filename
+/fonts/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Static images (favicon, OG default)
+/favicon.svg
+  Cache-Control: public, max-age=86400
+/favicon.ico
+  Cache-Control: public, max-age=86400
+/apple-touch-icon.png
+  Cache-Control: public, max-age=86400
+/og-default.jpg
+  Cache-Control: public, max-age=86400

--- a/src/components/CollectionCard.astro
+++ b/src/components/CollectionCard.astro
@@ -7,9 +7,10 @@ interface Props {
   slug: string
   coverImage: ContentfulAsset
   description?: string
+  loading?: 'lazy' | 'eager'
 }
 
-const { title, slug, coverImage, description } = Astro.props
+const { title, slug, coverImage, description, loading = 'lazy' } = Astro.props
 
 const src = imageUrl(coverImage, 800, 75)
 const srcset = masonrySrcset(coverImage)
@@ -25,7 +26,7 @@ const { width, height } = assetDimensions(coverImage)
       alt={description ?? title}
       width={width}
       height={height}
-      loading="lazy"
+      loading={loading}
       decoding="async"
       class="collection-card-img"
     />

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -29,6 +29,8 @@ const resolvedOgImage = ogImage ?? new URL('/og-default.jpg', Astro.site).toStri
 <meta property="og:description" content={description} />
 <meta property="og:url" content={canonicalUrl} />
 <meta property="og:image" content={resolvedOgImage} />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
 <meta property="og:site_name" content="Luke Cartledge" />
 <meta property="og:locale" content="en_US" />
 

--- a/src/components/PhotoCard.astro
+++ b/src/components/PhotoCard.astro
@@ -7,9 +7,10 @@ interface Props {
   title: string
   href?: string
   loading?: 'lazy' | 'eager'
+  fetchpriority?: 'high' | 'low' | 'auto'
 }
 
-const { image, title, href, loading = 'lazy' } = Astro.props
+const { image, title, href, loading = 'lazy', fetchpriority } = Astro.props
 
 const src = imageUrl(image, 600, 75)
 const srcset = masonrySrcset(image)
@@ -29,6 +30,7 @@ const displayHeight = Math.round(displayWidth * (naturalHeight / naturalWidth))
     height={displayHeight}
     loading={loading}
     decoding="async"
+    fetchpriority={fetchpriority}
   />
   <div class="photo-overlay">
     <span class="photo-title">{title}</span>

--- a/src/components/PhotoGrid.astro
+++ b/src/components/PhotoGrid.astro
@@ -19,7 +19,12 @@ const { photos } = Astro.props
   {
     photos.map((photo, index) => (
       <div class="gallery-grid-item">
-        <PhotoCard image={photo.image} title={photo.title} loading={index < 6 ? 'eager' : 'lazy'} />
+        <PhotoCard
+          image={photo.image}
+          title={photo.title}
+          loading={index < 3 ? 'eager' : 'lazy'}
+          fetchpriority={index === 0 ? 'high' : undefined}
+        />
       </div>
     ))
   }

--- a/src/pages/photography/[slug].astro
+++ b/src/pages/photography/[slug].astro
@@ -19,6 +19,7 @@ export async function getStaticPaths() {
 const { collection } = Astro.props
 
 const title = collection.title as string
+const description = (collection.description as string) ?? undefined
 
 const coverPhotoRef = collection.coverPhoto as { fields: Record<string, unknown> }
 const coverImage = coverPhotoRef.fields.image as ContentfulAsset
@@ -45,7 +46,7 @@ const breadcrumb = [
 const ogImage = ogImageUrl(coverImage)
 ---
 
-<Page title={`${title} — Photography — Luke Cartledge`} ogImage={ogImage}>
+<Page title={`${title} — Photography — Luke Cartledge`} description={description} ogImage={ogImage}>
   <section class="collection container">
     <Breadcrumb items={breadcrumb} />
 

--- a/src/pages/photography/index.astro
+++ b/src/pages/photography/index.astro
@@ -40,12 +40,13 @@ const ogImage = prepared[0]?.coverImage ? ogImageUrl(prepared[0].coverImage) : u
         <p class="empty-message">No collections yet.</p>
       ) : (
         <div class="collections-grid">
-          {prepared.map((item) => (
+          {prepared.map((item, index) => (
             <CollectionCard
               title={item.title}
               slug={item.slug}
               coverImage={item.coverImage}
               description={item.description}
+              loading={index < 2 ? 'eager' : 'lazy'}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary

Phase 9 performance and technical improvements — the first batch before the About page expansion.

### Changes

- **Dependency updates**: Astro 6.1.3 → 6.1.5, Contentful rich-text packages updated, axios + vite vulnerabilities patched
- **OG meta improvements**: Added `og:image:width` and `og:image:height` meta tags to `Head.astro` for faster social preview rendering
- **Image loading performance**: `fetchpriority="high"` on first photo (LCP candidate), eager loading tightened from 6 → 3 images in PhotoGrid, `CollectionCard` now supports eager loading for first 2 cards on `/photography`
- **Cache headers**: New `public/_headers` for Cloudflare Pages — immutable caching for `/_astro/*` and `/fonts/*`, 24h for static images

### Lighthouse Audit Results (pre-change baseline)

| Page | Perf | A11y | BP | SEO |
|---|:---:|:---:|:---:|:---:|
| `/` Homepage | 🟡 90 | 100 | 100 | 100 |
| `/photography` | 🟢 99 | 100 | 100 | 100 |
| `/about` | 🟢 99 | 100 | 100 | 100 |
| `/photography/iceland` | 🟢 99 | 100 | 100 | 100 |

Homepage LCP was 3.6s on mobile — the `fetchpriority` and eager loading changes should bring this under 2.5s. Re-audit after merge to verify.

### Verification

- `prettier --check .` ✅
- `eslint .` ✅
- `astro check` ✅ (0 errors, 7 pre-existing hints)
- `tsc --noEmit` ✅
- `astro build` ✅ (7 pages, 690ms)