### PR TITLE
Phase 12: SEO structured data

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -3,12 +3,14 @@ interface Props {
   title: string
   description?: string
   ogImage?: string
+  schema?: Record<string, unknown> | Record<string, unknown>[]
 }
 
 const {
   title,
   description = 'Landscape and travel photography by Luke Cartledge',
   ogImage,
+  schema,
 } = Astro.props
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site)
 const resolvedOgImage = ogImage ?? new URL('/og-default.jpg', Astro.site).toString()
@@ -46,6 +48,7 @@ const resolvedOgImage = ogImage ?? new URL('/og-default.jpg', Astro.site).toStri
 <meta name="twitter:title" content={title} />
 <meta name="twitter:description" content={description} />
 <meta name="twitter:image" content={resolvedOgImage} />
+{schema && <script type="application/ld+json" set:html={JSON.stringify(schema)} />}
 
 <link rel="preconnect" href="https://images.ctfassets.net" crossorigin />
 <link rel="preload" href="/fonts/Raleway-Latin.woff2" as="font" type="font/woff2" crossorigin />

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -8,15 +8,16 @@ interface Props {
   title: string
   description?: string
   ogImage?: string
+  schema?: Record<string, unknown> | Record<string, unknown>[]
 }
 
-const { title, description, ogImage } = Astro.props
+const { title, description, ogImage, schema } = Astro.props
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
-    <Head title={title} description={description} ogImage={ogImage} />
+    <Head title={title} description={description} ogImage={ogImage} schema={schema} />
     <ClientRouter />
   </head>
   <body>

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -9,9 +9,10 @@ interface Props {
   title: string
   description?: string
   ogImage?: string
+  schema?: Record<string, unknown> | Record<string, unknown>[]
 }
 
-const { title, description, ogImage } = Astro.props
+const { title, description, ogImage, schema } = Astro.props
 
 const siteConfigEntries = await getCollection('siteConfig')
 const config = siteConfigEntries[0]?.data
@@ -31,7 +32,7 @@ const socialLinks = Object.entries(rawLinks)
   }))
 ---
 
-<Base title={title} description={description} ogImage={ogImage}>
+<Base title={title} description={description} ogImage={ogImage} schema={schema}>
   <Header socialLinks={socialLinks} />
   <main id="main" transition:animate={fade({ duration: '0.25s' })}>
     <slot />

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -1,0 +1,170 @@
+type SchemaObject = Record<string, unknown>
+
+export function websiteSchema(name: string, url: string, description: string): SchemaObject {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name,
+    url,
+    description,
+  }
+}
+
+type PersonSchemaInput = {
+  name: string
+  description: string
+  url: string
+  image?: string
+  sameAs?: string[]
+}
+
+export function personSchema({
+  name,
+  description,
+  url,
+  image,
+  sameAs,
+}: PersonSchemaInput): SchemaObject {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name,
+    description,
+    url,
+    ...(image ? { image } : {}),
+    ...(sameAs && sameAs.length > 0 ? { sameAs } : {}),
+  }
+}
+
+type ImageGallerySchemaInput = {
+  name: string
+  description: string
+  url: string
+  images: SchemaObject[]
+}
+
+export function imageGallerySchema({
+  name,
+  description,
+  url,
+  images,
+}: ImageGallerySchemaInput): SchemaObject {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ImageGallery',
+    name,
+    description,
+    url,
+    hasPart: images,
+  }
+}
+
+type ExifData = {
+  camera?: string
+  lens?: string
+  aperture?: string
+  shutterSpeed?: string
+  iso?: string
+  [key: string]: string | undefined
+}
+
+type ImageObjectSchemaInput = {
+  name: string
+  contentUrl: string
+  description?: string
+  creator?: string | SchemaObject
+  locationCreated?: string
+  width?: number
+  height?: number
+  exifData?: ExifData
+}
+
+export function imageObjectSchema({
+  name,
+  contentUrl,
+  description,
+  creator,
+  locationCreated,
+  width,
+  height,
+  exifData,
+}: ImageObjectSchemaInput): SchemaObject {
+  const exifProperties = Object.entries(exifData ?? {})
+    .map(([propertyID, value]) => ({
+      '@type': 'PropertyValue',
+      propertyID,
+      value,
+    }))
+    .filter((item) => item.value)
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ImageObject',
+    name,
+    contentUrl,
+    ...(description ? { description } : {}),
+    ...(creator
+      ? {
+          creator:
+            typeof creator === 'string'
+              ? {
+                  '@type': 'Person',
+                  name: creator,
+                }
+              : creator,
+        }
+      : {}),
+    ...(locationCreated
+      ? {
+          locationCreated: {
+            '@type': 'Place',
+            name: locationCreated,
+          },
+        }
+      : {}),
+    ...(typeof width === 'number' ? { width } : {}),
+    ...(typeof height === 'number' ? { height } : {}),
+    ...(exifProperties.length > 0 ? { exifData: exifProperties } : {}),
+  }
+}
+
+type BreadcrumbItem = {
+  name: string
+  url?: string
+}
+
+export function breadcrumbSchema(items: BreadcrumbItem[]): SchemaObject {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      ...(item.url ? { item: item.url } : {}),
+    })),
+  }
+}
+
+type CollectionPageSchemaInput = {
+  name: string
+  url: string
+  description: string
+  hasPart: SchemaObject[]
+}
+
+export function collectionPageSchema({
+  name,
+  url,
+  description,
+  hasPart,
+}: CollectionPageSchemaInput): SchemaObject {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name,
+    url,
+    description,
+    hasPart,
+  }
+}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content'
 import Page from '@/layouts/Page.astro'
 import { documentToHtmlString } from '@contentful/rich-text-html-renderer'
 import { imageUrl, ogImageUrl, blurPlaceholder, assetDimensions } from '@/lib/image'
+import { personSchema } from '@/lib/jsonld'
 import type { ContentfulAsset } from '@/lib/image'
 
 const siteConfigEntries = await getCollection('siteConfig')
@@ -53,6 +54,20 @@ const socialLinks = Object.entries(rawLinks)
     label: labels[platform] ?? platform,
   }))
 
+const sameAs = [rawLinks.instagram, rawLinks.github].filter(
+  (url): url is string => typeof url === 'string' && url.length > 0,
+)
+
+const siteUrl = Astro.site?.toString() ?? 'https://lukecartledge.com'
+const profileImageUrl = profileImage ? imageUrl(profileImage, 800, 80) : undefined
+const schema = personSchema({
+  name: String(config.title),
+  description: String(description),
+  url: new URL('/about', siteUrl).toString(),
+  image: profileImageUrl,
+  sameAs,
+})
+
 const icons: Record<string, string> = {
   instagram: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"/><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"/><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"/></svg>`,
   email: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><polyline points="22,4 12,13 2,4"/></svg>`,
@@ -60,7 +75,7 @@ const icons: Record<string, string> = {
 }
 ---
 
-<Page title={title} description={description} ogImage={ogImage}>
+<Page title={title} description={description} ogImage={ogImage} schema={schema}>
   {/* Hero — full-width portrait with text overlay */}
   {
     portraitSrc && portraitDims && (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@ import Page from '@/layouts/Page.astro'
 import PhotoGrid from '@/components/PhotoGrid.astro'
 import PhotoLightbox from '@/components/PhotoLightbox.astro'
 import { ogImageUrl } from '@/lib/image'
+import { websiteSchema } from '@/lib/jsonld'
 import type { ContentfulAsset } from '@/lib/image'
 
 type PhotoWithExif = {
@@ -66,9 +67,11 @@ const description = seo?.description ?? config.tagline
 const ogImage = heroPhoto?.fields?.image
   ? ogImageUrl(heroPhoto.fields.image as ContentfulAsset)
   : undefined
+const siteUrl = Astro.site?.toString() ?? 'https://lukecartledge.com'
+const schema = websiteSchema(seo?.title ?? String(config.title), siteUrl, String(description))
 ---
 
-<Page title={title} description={description} ogImage={ogImage}>
+<Page title={title} description={description} ogImage={ogImage} schema={schema}>
   <section class="gallery container">
     {photos.length > 0 && <PhotoGrid photos={photos} />}
     <div class="gallery-cta">

--- a/src/pages/photography/[slug].astro
+++ b/src/pages/photography/[slug].astro
@@ -4,7 +4,8 @@ import Page from '@/layouts/Page.astro'
 import Breadcrumb from '@/components/Breadcrumb.astro'
 import PhotoGrid from '@/components/PhotoGrid.astro'
 import PhotoLightbox from '@/components/PhotoLightbox.astro'
-import { ogImageUrl } from '@/lib/image'
+import { imageUrl, ogImageUrl, assetDimensions } from '@/lib/image'
+import { imageGallerySchema, imageObjectSchema, breadcrumbSchema } from '@/lib/jsonld'
 import type { ContentfulAsset } from '@/lib/image'
 
 export async function getStaticPaths() {
@@ -44,9 +45,63 @@ const breadcrumb = [
 ]
 
 const ogImage = ogImageUrl(coverImage)
+const siteUrl = Astro.site?.toString() ?? 'https://lukecartledge.com'
+const pageUrl = new URL(`/photography/${collection.slug as string}`, siteUrl).toString()
+
+const imageObjects = photos.map((photo) => {
+  const dimensions = assetDimensions(photo.image)
+
+  return imageObjectSchema({
+    name: photo.title,
+    contentUrl: imageUrl(photo.image, dimensions.width, 85),
+    description,
+    creator: String(collection.photographer ?? 'Luke Cartledge'),
+    locationCreated: photo.location,
+    width: dimensions.width,
+    height: dimensions.height,
+    exifData: {
+      camera: photo.camera,
+      lens: photo.lens,
+      aperture: photo.aperture,
+      shutterSpeed: photo.shutterSpeed,
+      iso: photo.iso,
+    },
+  })
+})
+
+const galleryObj = imageGallerySchema({
+  name: title,
+  description: description ?? `${title} photography collection`,
+  url: pageUrl,
+  images: imageObjects,
+})
+
+const breadcrumbObj = breadcrumbSchema(
+  breadcrumb.map((item) => ({
+    name: item.label,
+    url: item.href ? new URL(item.href, siteUrl).toString() : undefined,
+  })),
+)
+
+const galleryWithoutContext = Object.fromEntries(
+  Object.entries(galleryObj).filter(([key]) => key !== '@context'),
+)
+const breadcrumbWithoutContext = Object.fromEntries(
+  Object.entries(breadcrumbObj).filter(([key]) => key !== '@context'),
+)
+
+const schema = {
+  '@context': 'https://schema.org',
+  '@graph': [galleryWithoutContext, breadcrumbWithoutContext],
+}
 ---
 
-<Page title={`${title} — Photography — Luke Cartledge`} description={description} ogImage={ogImage}>
+<Page
+  title={`${title} — Photography — Luke Cartledge`}
+  description={description}
+  ogImage={ogImage}
+  schema={schema}
+>
   <section class="collection container">
     <Breadcrumb items={breadcrumb} />
 

--- a/src/pages/photography/index.astro
+++ b/src/pages/photography/index.astro
@@ -5,6 +5,7 @@ import CollectionCard from '@/components/CollectionCard.astro'
 import Breadcrumb from '@/components/Breadcrumb.astro'
 import type { ContentfulAsset } from '@/lib/image'
 import { ogImageUrl } from '@/lib/image'
+import { collectionPageSchema } from '@/lib/jsonld'
 
 const allCollections = await getCollection('photoCollections')
 
@@ -29,9 +30,28 @@ const prepared = collections.map((collection) => {
 const breadcrumb = [{ label: 'Home', href: '/' }, { label: 'Photography' }]
 
 const ogImage = prepared[0]?.coverImage ? ogImageUrl(prepared[0].coverImage) : undefined
+const siteUrl = Astro.site?.toString() ?? 'https://lukecartledge.com'
+const pageUrl = new URL('/photography', siteUrl).toString()
+const pageDescription = 'Photography collections by Luke Cartledge'
+const schema = collectionPageSchema({
+  name: 'Photography',
+  url: pageUrl,
+  description: pageDescription,
+  hasPart: prepared.map((item) => ({
+    '@type': 'CollectionPage',
+    name: item.title,
+    url: new URL(`/photography/${item.slug}`, siteUrl).toString(),
+    ...(item.description ? { description: item.description } : {}),
+  })),
+})
 ---
 
-<Page title="Photography — Luke Cartledge" ogImage={ogImage}>
+<Page
+  title="Photography — Luke Cartledge"
+  description="Photography collections by Luke Cartledge"
+  ogImage={ogImage}
+  schema={schema}
+>
   <section class="photography container">
     <Breadcrumb items={breadcrumb} />
 

--- a/src/pages/sitemap-images.xml.ts
+++ b/src/pages/sitemap-images.xml.ts
@@ -1,0 +1,107 @@
+import type { APIRoute } from 'astro'
+import { getCollection } from 'astro:content'
+import { imageUrl } from '@/lib/image'
+import type { ContentfulAsset } from '@/lib/image'
+
+const SITE_URL = 'https://lukecartledge.com'
+
+type EntryImage = {
+  url: string
+  title?: string
+}
+
+function isDefined<T>(value: T | null): value is T {
+  return value !== null
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;')
+}
+
+function toAbsoluteUrl(pathname: string): string {
+  return new URL(pathname, SITE_URL).toString()
+}
+
+function imageEntryFromPhotoRef(ref: { fields: Record<string, unknown> }): EntryImage | null {
+  const image = ref.fields.image as ContentfulAsset | undefined
+  if (!image) return null
+
+  return {
+    url: imageUrl(image, 2400, 85),
+    title: (ref.fields.title as string) ?? undefined,
+  }
+}
+
+function renderUrlNode(pageUrl: string, images: EntryImage[]): string {
+  const imageNodes = images
+    .map((image) => {
+      const titleNode = image.title ? `<image:title>${escapeXml(image.title)}</image:title>` : ''
+
+      return `<image:image><image:loc>${escapeXml(image.url)}</image:loc>${titleNode}</image:image>`
+    })
+    .join('')
+
+  return `<url><loc>${escapeXml(pageUrl)}</loc>${imageNodes}</url>`
+}
+
+export const GET: APIRoute = async () => {
+  const allCollections = await getCollection('photoCollections')
+  const siteConfigEntries = await getCollection('siteConfig')
+  const allPhotos = await getCollection('photos')
+
+  const collectionUrls = allCollections
+    .map((entry) => {
+      const collection = entry.data
+      const slug = collection.slug as string
+      const photoRefs = (collection.photos as Array<{ fields: Record<string, unknown> }>) ?? []
+
+      const images = photoRefs.map((photoRef) => imageEntryFromPhotoRef(photoRef)).filter(isDefined)
+
+      if (images.length === 0) return null
+
+      return {
+        pageUrl: toAbsoluteUrl(`/photography/${slug}`),
+        images,
+      }
+    })
+    .filter((item): item is { pageUrl: string; images: EntryImage[] } => item !== null)
+
+  const config = siteConfigEntries[0]?.data
+  const featuredPhotoRefs = (config?.featuredPhotos ?? []) as Array<{
+    fields: Record<string, unknown>
+  }>
+
+  const homepageImages =
+    featuredPhotoRefs.length > 0
+      ? featuredPhotoRefs.map((photoRef) => imageEntryFromPhotoRef(photoRef)).filter(isDefined)
+      : allPhotos
+          .map((entry) => entry.data)
+          .map((photo): EntryImage | null => {
+            const image = photo.image as ContentfulAsset | undefined
+            if (!image) return null
+
+            return {
+              url: imageUrl(image, 2400, 85),
+              title: (photo.title as string | undefined) ?? undefined,
+            }
+          })
+          .filter(isDefined)
+
+  const urlNodes = [
+    renderUrlNode(toAbsoluteUrl('/'), homepageImages),
+    ...collectionUrls.map((item) => renderUrlNode(item.pageUrl, item.images)),
+  ].join('')
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">${urlNodes}</urlset>`
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  })
+}


### PR DESCRIPTION
## Summary

- Add JSON-LD structured data to all pages (WebSite, Person, CollectionPage, ImageGallery, BreadcrumbList)
- Add image sitemap endpoint at `/sitemap-images.xml` with per-gallery photo URLs
- Fix about page canonical URL (missing slash)
- Fix missing description prop on photography index page

## Details

**JSON-LD schemas (`src/lib/jsonld.ts`)**
Typed builder functions for all schema types. Gallery pages use `@graph` to combine ImageGallery + BreadcrumbList. Photo `ImageObject` entries include EXIF metadata when available.

**Layout prop threading**
New optional `schema` prop flows through `Page.astro → Base.astro → Head.astro`, rendered as `<script type="application/ld+json">`.

**Image sitemap (`src/pages/sitemap-images.xml.ts`)**
Custom endpoint since `@astrojs/sitemap` doesn't support image extensions. Fetches all galleries from Contentful and generates `<image:image>` entries per photo.

## Verification

- `npm run lint` — 0 errors, 0 warnings
- `npm run build` — 7 pages built, sitemap-images.xml generated
- Post-deploy: validate with Google Rich Results Test
- Post-deploy: submit image sitemap to Google Search Console