### PR TITLE
Skip preview deploy for Dependabot PRs

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -24,13 +24,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Lint
-        run: npm run lint
+      - name: Lint (format + eslint)
+        run: prettier --check . && eslint .
+
+      - name: Lint (types)
+        if: github.actor != 'dependabot[bot]'
+        run: astro check && tsc --noEmit
         env:
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
           CONTENTFUL_DELIVERY_TOKEN: ${{ secrets.CONTENTFUL_DELIVERY_TOKEN }}
 
       - name: Build
+        if: github.actor != 'dependabot[bot]'
         run: npm run build
         env:
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Lint (types)
         if: github.actor != 'dependabot[bot]'
-        run: astro check && tsc --noEmit
+        run: npx astro check && npx tsc --noEmit
         env:
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
           CONTENTFUL_DELIVERY_TOKEN: ${{ secrets.CONTENTFUL_DELIVERY_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -37,6 +37,7 @@ jobs:
           CONTENTFUL_DELIVERY_TOKEN: ${{ secrets.CONTENTFUL_DELIVERY_TOKEN }}
 
       - name: Deploy preview to CF Pages
+        if: github.actor != 'dependabot[bot]'
         id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
@@ -46,6 +47,7 @@ jobs:
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment preview URL on PR
+        if: github.actor != 'dependabot[bot]'
         uses: actions/github-script@v8
         with:
           script: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,7 +25,7 @@ jobs:
         run: npm ci
 
       - name: Lint (format + eslint)
-        run: prettier --check . && eslint .
+        run: npx prettier --check . && npx eslint .
 
       - name: Lint (types)
         if: github.actor != 'dependabot[bot]'


### PR DESCRIPTION
## Summary

- Skip Cloudflare Pages deploy and PR comment steps when the actor is `dependabot[bot]`
- Dependabot PRs still get lint + build verification to catch breaking changes
- Avoids needing to duplicate Cloudflare secrets into the Dependabot secrets store