### PR TITLE
Phase 12b: Wire Contentful SEO fields into frontend

### DIFF
--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -4,6 +4,8 @@ import { getCollection } from 'astro:content'
 import Base from '@/layouts/Base.astro'
 import Header from '@/components/Header.astro'
 import Footer from '@/components/Footer.astro'
+import { ogImageUrl } from '@/lib/image'
+import type { ContentfulAsset } from '@/lib/image'
 
 interface Props {
   title: string
@@ -16,6 +18,10 @@ const { title, description, ogImage, schema } = Astro.props
 
 const siteConfigEntries = await getCollection('siteConfig')
 const config = siteConfigEntries[0]?.data
+
+// Global OG image fallback from CMS (Phase 12b)
+const siteOgAsset = config?.seoOgImage as ContentfulAsset | undefined
+const resolvedOgImage = ogImage ?? (siteOgAsset ? ogImageUrl(siteOgAsset) : undefined)
 
 const labels: Record<string, string> = {
   instagram: 'Instagram',
@@ -32,7 +38,7 @@ const socialLinks = Object.entries(rawLinks)
   }))
 ---
 
-<Base title={title} description={description} ogImage={ogImage} schema={schema}>
+<Base title={title} description={description} ogImage={resolvedOgImage} schema={schema}>
   <Header socialLinks={socialLinks} />
   <main id="main" transition:animate={fade({ duration: '0.25s' })}>
     <slot />

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -5,9 +5,8 @@ import Page from '@/layouts/Page.astro'
 import { ogImageUrl } from '@/lib/image'
 import type { ContentfulAsset } from '@/lib/image'
 
-const RESERVED_SLUGS = ['about', 'photography', '404']
-
 export async function getStaticPaths() {
+  const RESERVED_SLUGS = ['about', 'photography', '404']
   const allPages = await getCollection('pages')
 
   return allPages

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,0 +1,116 @@
+---
+import { getCollection } from 'astro:content'
+import { documentToHtmlString } from '@contentful/rich-text-html-renderer'
+import Page from '@/layouts/Page.astro'
+import { ogImageUrl } from '@/lib/image'
+import type { ContentfulAsset } from '@/lib/image'
+
+const RESERVED_SLUGS = ['about', 'photography', '404']
+
+export async function getStaticPaths() {
+  const allPages = await getCollection('pages')
+
+  return allPages
+    .filter((page) => {
+      const slug = page.data.slug as string
+      if (RESERVED_SLUGS.includes(slug)) {
+        console.warn(`[pages] Skipping page "${slug}" — conflicts with existing route`)
+        return false
+      }
+      return true
+    })
+    .map((page) => ({
+      params: { slug: page.data.slug as string },
+      props: { page: page.data },
+    }))
+}
+
+const { page } = Astro.props
+
+const title = (page.seoMetaTitle as string) ?? (page.title as string)
+const description = (page.seoMetaDescription as string) ?? undefined
+const seoOgImage = page.seoOgImage as ContentfulAsset | undefined
+const ogImage = seoOgImage ? ogImageUrl(seoOgImage) : undefined
+
+const bodyHtml = page.body ? documentToHtmlString(page.body) : ''
+---
+
+<Page title={title} description={description} ogImage={ogImage}>
+  <article class="page-content container">
+    <h1>{page.title}</h1>
+    {bodyHtml && <div class="prose" set:html={bodyHtml} />}
+  </article>
+</Page>
+
+<style>
+  .page-content {
+    padding-block: var(--space-16);
+    max-width: var(--max-prose);
+    margin-inline: auto;
+  }
+
+  .page-content h1 {
+    font-family: var(--font-heading);
+    font-size: var(--text-3xl);
+    font-weight: 700;
+    margin-bottom: var(--space-8);
+  }
+
+  .prose :global(p) {
+    font-size: var(--text-base);
+    line-height: var(--leading-relaxed);
+    color: var(--color-text);
+  }
+
+  .prose :global(p + p) {
+    margin-top: var(--space-4);
+  }
+
+  .prose :global(h2) {
+    font-family: var(--font-heading);
+    font-size: var(--text-xl);
+    font-weight: 700;
+    margin-top: var(--space-8);
+    margin-bottom: var(--space-3);
+  }
+
+  .prose :global(h3) {
+    font-family: var(--font-heading);
+    font-size: var(--text-lg);
+    font-weight: 700;
+    margin-top: var(--space-8);
+    margin-bottom: var(--space-3);
+  }
+
+  .prose :global(ul),
+  .prose :global(ol) {
+    margin-top: var(--space-3);
+    margin-bottom: var(--space-3);
+    padding-left: var(--space-6);
+  }
+
+  .prose :global(li) {
+    font-size: var(--text-base);
+    line-height: var(--leading-relaxed);
+    color: var(--color-text);
+  }
+
+  .prose :global(li + li) {
+    margin-top: var(--space-1);
+  }
+
+  .prose :global(strong) {
+    font-weight: 600;
+  }
+
+  .prose :global(a) {
+    color: var(--color-text);
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+    transition: color var(--duration-fast) var(--ease-out);
+  }
+
+  .prose :global(a:hover) {
+    color: var(--color-text-muted);
+  }
+</style>

--- a/src/pages/photography/[slug].astro
+++ b/src/pages/photography/[slug].astro
@@ -22,6 +22,11 @@ const { collection } = Astro.props
 const title = collection.title as string
 const description = (collection.description as string) ?? undefined
 
+// SEO override fields (Phase 12b)
+const seoMetaTitle = (collection.seoMetaTitle as string) ?? undefined
+const seoMetaDescription = (collection.seoMetaDescription as string) ?? undefined
+const seoOgImage = collection.seoOgImage as ContentfulAsset | undefined
+
 const coverPhotoRef = collection.coverPhoto as { fields: Record<string, unknown> }
 const coverImage = coverPhotoRef.fields.image as ContentfulAsset
 
@@ -44,7 +49,7 @@ const breadcrumb = [
   { label: title },
 ]
 
-const ogImage = ogImageUrl(coverImage)
+const ogImage = seoOgImage ? ogImageUrl(seoOgImage) : ogImageUrl(coverImage)
 const siteUrl = Astro.site?.toString() ?? 'https://lukecartledge.com'
 const pageUrl = new URL(`/photography/${collection.slug as string}`, siteUrl).toString()
 
@@ -97,8 +102,8 @@ const schema = {
 ---
 
 <Page
-  title={`${title} — Photography — Luke Cartledge`}
-  description={description}
+  title={seoMetaTitle ?? `${title} — Photography — Luke Cartledge`}
+  description={seoMetaDescription ?? description}
   ogImage={ogImage}
   schema={schema}
 >


### PR DESCRIPTION
## Summary

Wire 10 previously unused Contentful SEO fields into the Astro frontend so content editors can control meta titles, descriptions, and Open Graph images per page from the CMS.

## Changes

- **Global OG fallback** (`Page.astro`): Extract `siteConfig.seoOgImage` and inject into the layout chain. Fallback order: page-specific `ogImage` → `siteConfig.seoOgImage` → `/og-default.jpg`
- **Collection SEO overrides** (`photography/[slug].astro`): Read `seoMetaTitle`, `seoMetaDescription`, `seoOgImage` from collection entries with nullish coalescing fallback to existing derived values
- **Page content type route** (`[...slug].astro`): New catch-all route for the `page` content type with Rich Text rendering, full SEO field threading, and reserved slug validation

## Testing

- `astro build` passes — 7 pages, zero errors
- LSP diagnostics clean on all 3 files
- `pages` collection empty message is expected (no page entries in Contentful yet)

## Notes

- Part of PLAN.md Phase 12b
- Photo-level SEO fields (`seoMetaTitle`, `seoMetaDescription`, `seoOgImage` on `photo` content type) are documented as reserved for future individual photo pages