### PR TITLE
Phase 12b: SEO fields integration and GSC indexing fixes

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,5 +4,9 @@ import sitemap from '@astrojs/sitemap'
 export default defineConfig({
   site: 'https://lukecartledge.com',
   output: 'static',
+  trailingSlash: 'never',
+  build: {
+    format: 'file',
+  },
   integrations: [sitemap()],
 })

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,5 +8,9 @@ export default defineConfig({
   build: {
     format: 'file',
   },
-  integrations: [sitemap()],
+  integrations: [
+    sitemap({
+      filter: (page) => !page.includes('sitemap-images'),
+    }),
+  ],
 })

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,2 @@
+# Redirect deleted photo detail pages to photography index
+/photo/*  /photography  301

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -12,7 +12,8 @@ const {
   ogImage,
   schema,
 } = Astro.props
-const canonicalUrl = new URL(Astro.url.pathname, Astro.site)
+const pathname = Astro.url.pathname.replace(/\/$/, '') || '/'
+const canonicalUrl = new URL(pathname, Astro.site)
 const resolvedOgImage = ogImage ?? new URL('/og-default.jpg', Astro.site).toString()
 ---
 

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -4,6 +4,8 @@ import { getCollection } from 'astro:content'
 import Base from '@/layouts/Base.astro'
 import Header from '@/components/Header.astro'
 import Footer from '@/components/Footer.astro'
+import { ogImageUrl } from '@/lib/image'
+import type { ContentfulAsset } from '@/lib/image'
 
 interface Props {
   title: string
@@ -16,6 +18,10 @@ const { title, description, ogImage, schema } = Astro.props
 
 const siteConfigEntries = await getCollection('siteConfig')
 const config = siteConfigEntries[0]?.data
+
+// Global OG image fallback from CMS (Phase 12b)
+const siteOgAsset = config?.seoOgImage as ContentfulAsset | undefined
+const resolvedOgImage = ogImage ?? (siteOgAsset ? ogImageUrl(siteOgAsset) : undefined)
 
 const labels: Record<string, string> = {
   instagram: 'Instagram',
@@ -32,7 +38,7 @@ const socialLinks = Object.entries(rawLinks)
   }))
 ---
 
-<Base title={title} description={description} ogImage={ogImage} schema={schema}>
+<Base title={title} description={description} ogImage={resolvedOgImage} schema={schema}>
   <Header socialLinks={socialLinks} />
   <main id="main" transition:animate={fade({ duration: '0.25s' })}>
     <slot />

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -5,9 +5,8 @@ import Page from '@/layouts/Page.astro'
 import { ogImageUrl } from '@/lib/image'
 import type { ContentfulAsset } from '@/lib/image'
 
-const RESERVED_SLUGS = ['about', 'photography', '404']
-
 export async function getStaticPaths() {
+  const RESERVED_SLUGS = ['about', 'photography', '404']
   const allPages = await getCollection('pages')
 
   return allPages

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,0 +1,116 @@
+---
+import { getCollection } from 'astro:content'
+import { documentToHtmlString } from '@contentful/rich-text-html-renderer'
+import Page from '@/layouts/Page.astro'
+import { ogImageUrl } from '@/lib/image'
+import type { ContentfulAsset } from '@/lib/image'
+
+const RESERVED_SLUGS = ['about', 'photography', '404']
+
+export async function getStaticPaths() {
+  const allPages = await getCollection('pages')
+
+  return allPages
+    .filter((page) => {
+      const slug = page.data.slug as string
+      if (RESERVED_SLUGS.includes(slug)) {
+        console.warn(`[pages] Skipping page "${slug}" — conflicts with existing route`)
+        return false
+      }
+      return true
+    })
+    .map((page) => ({
+      params: { slug: page.data.slug as string },
+      props: { page: page.data },
+    }))
+}
+
+const { page } = Astro.props
+
+const title = (page.seoMetaTitle as string) ?? (page.title as string)
+const description = (page.seoMetaDescription as string) ?? undefined
+const seoOgImage = page.seoOgImage as ContentfulAsset | undefined
+const ogImage = seoOgImage ? ogImageUrl(seoOgImage) : undefined
+
+const bodyHtml = page.body ? documentToHtmlString(page.body) : ''
+---
+
+<Page title={title} description={description} ogImage={ogImage}>
+  <article class="page-content container">
+    <h1>{page.title}</h1>
+    {bodyHtml && <div class="prose" set:html={bodyHtml} />}
+  </article>
+</Page>
+
+<style>
+  .page-content {
+    padding-block: var(--space-16);
+    max-width: var(--max-prose);
+    margin-inline: auto;
+  }
+
+  .page-content h1 {
+    font-family: var(--font-heading);
+    font-size: var(--text-3xl);
+    font-weight: 700;
+    margin-bottom: var(--space-8);
+  }
+
+  .prose :global(p) {
+    font-size: var(--text-base);
+    line-height: var(--leading-relaxed);
+    color: var(--color-text);
+  }
+
+  .prose :global(p + p) {
+    margin-top: var(--space-4);
+  }
+
+  .prose :global(h2) {
+    font-family: var(--font-heading);
+    font-size: var(--text-xl);
+    font-weight: 700;
+    margin-top: var(--space-8);
+    margin-bottom: var(--space-3);
+  }
+
+  .prose :global(h3) {
+    font-family: var(--font-heading);
+    font-size: var(--text-lg);
+    font-weight: 700;
+    margin-top: var(--space-8);
+    margin-bottom: var(--space-3);
+  }
+
+  .prose :global(ul),
+  .prose :global(ol) {
+    margin-top: var(--space-3);
+    margin-bottom: var(--space-3);
+    padding-left: var(--space-6);
+  }
+
+  .prose :global(li) {
+    font-size: var(--text-base);
+    line-height: var(--leading-relaxed);
+    color: var(--color-text);
+  }
+
+  .prose :global(li + li) {
+    margin-top: var(--space-1);
+  }
+
+  .prose :global(strong) {
+    font-weight: 600;
+  }
+
+  .prose :global(a) {
+    color: var(--color-text);
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+    transition: color var(--duration-fast) var(--ease-out);
+  }
+
+  .prose :global(a:hover) {
+    color: var(--color-text-muted);
+  }
+</style>

--- a/src/pages/photography/[slug].astro
+++ b/src/pages/photography/[slug].astro
@@ -22,6 +22,11 @@ const { collection } = Astro.props
 const title = collection.title as string
 const description = (collection.description as string) ?? undefined
 
+// SEO override fields (Phase 12b)
+const seoMetaTitle = (collection.seoMetaTitle as string) ?? undefined
+const seoMetaDescription = (collection.seoMetaDescription as string) ?? undefined
+const seoOgImage = collection.seoOgImage as ContentfulAsset | undefined
+
 const coverPhotoRef = collection.coverPhoto as { fields: Record<string, unknown> }
 const coverImage = coverPhotoRef.fields.image as ContentfulAsset
 
@@ -44,7 +49,7 @@ const breadcrumb = [
   { label: title },
 ]
 
-const ogImage = ogImageUrl(coverImage)
+const ogImage = seoOgImage ? ogImageUrl(seoOgImage) : ogImageUrl(coverImage)
 const siteUrl = Astro.site?.toString() ?? 'https://lukecartledge.com'
 const pageUrl = new URL(`/photography/${collection.slug as string}`, siteUrl).toString()
 
@@ -97,8 +102,8 @@ const schema = {
 ---
 
 <Page
-  title={`${title} — Photography — Luke Cartledge`}
-  description={description}
+  title={seoMetaTitle ?? `${title} — Photography — Luke Cartledge`}
+  description={seoMetaDescription ?? description}
   ogImage={ogImage}
   schema={schema}
 >


### PR DESCRIPTION
## Summary

- Wire Contentful SEO override fields (OG image, meta) on photography and CMS pages
- Add catch-all `[...slug]` route for the `page` content type with reserved slug guards
- Fix Google Search Console indexing issues (9 pages not indexed → 5 reasons)

## GSC Fixes

| GSC Issue | Root Cause | Fix |
|-----------|-----------|-----|
| Alternative page with proper canonical tag (3) | Cloudflare Pages 308 trailing-slash redirects | `build.format: 'file'` + `trailingSlash: 'never'` |
| Not found 404 (1) | Deleted `/photo/*` detail pages | `_redirects` with 301 to `/photography` |
| Page with redirect (1) | CF Pages trailing-slash 308 | Eliminated by `build.format: 'file'` |
| Discovered – currently not indexed (3) | `sitemap-images.xml` in HTML sitemap | Filtered from `@astrojs/sitemap` output |
| Crawled - currently not indexed (1) | Thin content / crawl timing | Re-request indexing after deploy |

## Changes

- `astro.config.mjs` — `trailingSlash: 'never'`, `build.format: 'file'`, sitemap filter
- `src/components/Head.astro` — Normalize canonical URL (strip trailing slashes)
- `public/_redirects` — 301 redirect `/photo/*` → `/photography`
- `src/pages/[...slug].astro` — Catch-all route for Contentful `page` content type
- `src/pages/photography/[slug].astro` — SEO field overrides
- `src/layouts/Page.astro` — SEO prop passthrough

## Post-Deploy

1. Submit affected URLs for re-indexing in GSC
2. Verify sitemap at `/sitemap-index.xml` shows no trailing slashes
3. Confirm `/photo/*` returns 301 → `/photography`