### PR TITLE
Fix canonical URLs including .html extension

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -12,7 +12,10 @@ const {
   ogImage,
   schema,
 } = Astro.props
-const pathname = Astro.url.pathname.replace(/\/$/, '') || '/'
+const pathname = Astro.url.pathname
+  .replace(/\/index\.html$/, '/')
+  .replace(/\.html$/, '')
+  .replace(/\/$/, '') || '/'
 const canonicalUrl = new URL(pathname, Astro.site)
 const resolvedOgImage = ogImage ?? new URL('/og-default.jpg', Astro.site).toString()
 ---

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -12,10 +12,11 @@ const {
   ogImage,
   schema,
 } = Astro.props
-const pathname = Astro.url.pathname
-  .replace(/\/index\.html$/, '/')
-  .replace(/\.html$/, '')
-  .replace(/\/$/, '') || '/'
+const pathname =
+  Astro.url.pathname
+    .replace(/\/index\.html$/, '/')
+    .replace(/\.html$/, '')
+    .replace(/\/$/, '') || '/'
 const canonicalUrl = new URL(pathname, Astro.site)
 const resolvedOgImage = ogImage ?? new URL('/og-default.jpg', Astro.site).toString()
 ---


### PR DESCRIPTION
## Summary

- Strip `.html` extension from canonical URL and `og:url` meta tag generation in `Head.astro`

## Problem

With `build.format: 'file'`, `Astro.url.pathname` returns paths like `/photography.html` during SSG. Cloudflare Pages serves these at clean URLs (`/photography`) and 308 redirects `.html` requests. The canonical tag was pointing to URLs that redirect, causing GSC validation failures:

- **Page with redirect** (6 URLs)
- **Alternative page with proper canonical tag** (3 URLs)
- **Duplicate, Google chose different canonical than user** (1 URL)

## Fix

Normalize the pathname by stripping `/index.html` → `/` and `.html` → `` before constructing the canonical URL.

## Verification

Build output confirmed:
- `rel="canonical"` and `og:url` now use clean URLs (no `.html`)
- Sitemap URLs are also clean