### PR TITLE
Phase 1: Keyboard access & focus system

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -53,7 +53,14 @@ const navLinks = [
       <ThemeToggle />
     </nav>
 
-    <label class="hamburger" for="mobile-nav-toggle" aria-label="Open menu">
+    <button
+      type="button"
+      class="hamburger"
+      aria-label="Open menu"
+      aria-expanded="false"
+      aria-controls="mobile-nav-overlay"
+      data-nav-open
+    >
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="24"
@@ -69,7 +76,7 @@ const navLinks = [
         <line x1="3" y1="12" x2="21" y2="12"></line>
         <line x1="3" y1="18" x2="21" y2="18"></line>
       </svg>
-    </label>
+    </button>
   </div>
 </header>
 
@@ -81,10 +88,10 @@ const navLinks = [
   tabindex="-1"
   transition:persist
 />
-<div class="mobile-nav-overlay" aria-hidden="true" transition:persist>
-  <label class="mobile-nav-overlay-bg" for="mobile-nav-toggle"></label>
+<div class="mobile-nav-overlay" id="mobile-nav-overlay" aria-hidden="true" transition:persist>
+  <div class="mobile-nav-overlay-bg" aria-hidden="true" data-nav-close></div>
   <nav class="mobile-nav-panel" aria-label="Mobile navigation">
-    <label class="mobile-nav-close" for="mobile-nav-toggle" aria-label="Close menu">
+    <button type="button" class="mobile-nav-close" aria-label="Close menu" data-nav-close>
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="24"
@@ -99,7 +106,7 @@ const navLinks = [
         <line x1="18" y1="6" x2="6" y2="18"></line>
         <line x1="6" y1="6" x2="18" y2="18"></line>
       </svg>
-    </label>
+    </button>
     <div class="mobile-nav-links">
       {
         navLinks.map((link) => (
@@ -132,11 +139,28 @@ const navLinks = [
 
 <script is:inline>
   ;(function () {
-    if (window.__mobileNavCloseInit) return
-    window.__mobileNavCloseInit = true
-    document.addEventListener('astro:before-preparation', function () {
+    if (window.__mobileNavInit) return
+    window.__mobileNavInit = true
+
+    function setOpen(open) {
       const checkbox = document.getElementById('mobile-nav-toggle')
-      if (checkbox) checkbox.checked = false
+      const overlay = document.getElementById('mobile-nav-overlay')
+      const trigger = document.querySelector('.hamburger')
+      if (checkbox) checkbox.checked = open
+      if (overlay) overlay.setAttribute('aria-hidden', open ? 'false' : 'true')
+      if (trigger) trigger.setAttribute('aria-expanded', open ? 'true' : 'false')
+    }
+
+    document.addEventListener('click', function (e) {
+      if (e.target.closest('[data-nav-open]')) {
+        setOpen(true)
+      } else if (e.target.closest('[data-nav-close]')) {
+        setOpen(false)
+      }
+    })
+
+    document.addEventListener('astro:before-preparation', function () {
+      setOpen(false)
     })
   })()
 </script>
@@ -212,6 +236,9 @@ const navLinks = [
     align-items: center;
     cursor: pointer;
     color: var(--color-text);
+    padding: 0;
+    border: none;
+    background: none;
   }
 
   .mobile-nav-overlay {
@@ -250,6 +277,9 @@ const navLinks = [
     cursor: pointer;
     color: var(--color-text);
     display: flex;
+    padding: 0;
+    border: none;
+    background: none;
   }
 
   .mobile-nav-links {

--- a/src/components/PhotoCard.astro
+++ b/src/components/PhotoCard.astro
@@ -20,7 +20,7 @@ const displayWidth = 600
 const displayHeight = Math.round(displayWidth * (naturalHeight / naturalWidth))
 ---
 
-<figure class="photo-card" data-photo-id={href}>
+<button type="button" class="photo-card" data-photo-id={href} aria-label={`View ${title}`}>
   <img
     src={src}
     srcset={srcset}
@@ -32,10 +32,10 @@ const displayHeight = Math.round(displayWidth * (naturalHeight / naturalWidth))
     decoding="async"
     fetchpriority={fetchpriority}
   />
-  <div class="photo-overlay">
+  <span class="photo-overlay">
     <span class="photo-title">{title}</span>
-  </div>
-</figure>
+  </span>
+</button>
 
 <style>
   .photo-card {
@@ -43,6 +43,13 @@ const displayHeight = Math.round(displayWidth * (naturalHeight / naturalWidth))
     overflow: hidden;
     cursor: pointer;
     line-height: 0;
+    display: block;
+    width: 100%;
+    padding: 0;
+    border: none;
+    background: none;
+    color: inherit;
+    font: inherit;
   }
 
   .photo-card img {
@@ -67,7 +74,8 @@ const displayHeight = Math.round(displayWidth * (naturalHeight / naturalWidth))
     transition: opacity 200ms ease;
   }
 
-  .photo-card:hover .photo-overlay {
+  .photo-card:hover .photo-overlay,
+  .photo-card:focus-visible .photo-overlay {
     opacity: 1;
   }
 

--- a/src/components/PhotoLightbox.astro
+++ b/src/components/PhotoLightbox.astro
@@ -314,6 +314,12 @@ const lightboxData = photos.map((p) => {
       opacity 300ms var(--ease-out);
   }
 
+  /* The global accent outline is invisible against the lightbox backdrop */
+  .lightbox :focus-visible {
+    outline: 2px solid #ffffff;
+    outline-offset: 3px;
+  }
+
   .lightbox-backdrop {
     position: absolute;
     inset: 0;

--- a/src/components/PhotoLightbox.astro
+++ b/src/components/PhotoLightbox.astro
@@ -115,11 +115,32 @@ const lightboxData = photos.map((p) => {
     window.__lightboxInit = true
 
     let currentIndex = -1
+    let lastFocused = null
     const LIGHTBOX_SIZES_ATTR =
       '(max-aspect-ratio: 3/4) min(90vw, calc(80vh * 0.75)), min(90vw, calc(80vh * 1.5))'
+    const BACKGROUND_SELECTOR = '.header, #main, .footer'
 
     function getData() {
       return window.__lightboxData || []
+    }
+
+    function setBackgroundInert(inert) {
+      document.querySelectorAll(BACKGROUND_SELECTOR).forEach(function (el) {
+        if (inert) {
+          el.setAttribute('inert', '')
+        } else {
+          el.removeAttribute('inert')
+        }
+      })
+    }
+
+    // Rendered controls only — .lightbox-nav is display:none below 640px
+    function getFocusable() {
+      const lightbox = document.getElementById('lightbox')
+      if (!lightbox) return []
+      return Array.from(lightbox.querySelectorAll('button:not([disabled])')).filter(function (el) {
+        return el.getClientRects().length > 0
+      })
     }
 
     function preloadAdjacentImages(index) {
@@ -142,6 +163,8 @@ const lightboxData = photos.map((p) => {
     function openLightbox(index) {
       const data = getData()
       if (index < 0 || index >= data.length) return
+      // Distinguish a fresh open from prev/next navigation, which reuses this
+      const wasClosed = currentIndex === -1
       currentIndex = index
       const photo = data[currentIndex]
 
@@ -180,12 +203,27 @@ const lightboxData = photos.map((p) => {
       lightboxCaptionLocation.style.display = photo.location ? '' : 'none'
       lightboxCaptionExif.textContent = photo.exif
       lightboxCaptionExif.style.display = photo.exif ? '' : 'none'
+
+      if (wasClosed) {
+        lastFocused = document.activeElement
+        setBackgroundInert(true)
+      }
+
       lightbox.classList.add('is-open')
       lightbox.setAttribute('aria-hidden', 'false')
       document.body.style.overflow = 'hidden'
       document.body.classList.add('lightbox-active')
       const header = document.querySelector('.header')
       if (header) header.style.visibility = 'hidden'
+
+      if (wasClosed) {
+        // Wait for the visibility change to apply before focusing
+        requestAnimationFrame(function () {
+          const closeBtn = lightbox.querySelector('.lightbox-close')
+          if (closeBtn) closeBtn.focus()
+        })
+      }
+
       preloadAdjacentImages(index)
     }
 
@@ -202,6 +240,13 @@ const lightboxData = photos.map((p) => {
       document.querySelectorAll('link[data-lightbox-preload]').forEach(function (el) {
         el.remove()
       })
+
+      // Must clear inert before restoring focus — inert elements reject focus()
+      setBackgroundInert(false)
+      if (lastFocused && typeof lastFocused.focus === 'function') {
+        lastFocused.focus()
+      }
+      lastFocused = null
     }
 
     function showPrev() {
@@ -234,6 +279,27 @@ const lightboxData = photos.map((p) => {
       if (e.key === 'Escape') closeLightbox()
       if (e.key === 'ArrowLeft') showPrev()
       if (e.key === 'ArrowRight') showNext()
+      if (e.key !== 'Tab') return
+
+      const lightbox = document.getElementById('lightbox')
+      const focusable = getFocusable()
+      if (!lightbox || !focusable.length) {
+        e.preventDefault()
+        return
+      }
+
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      const active = document.activeElement
+      const outside = !lightbox.contains(active)
+
+      if (e.shiftKey && (active === first || outside)) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && (active === last || outside)) {
+        e.preventDefault()
+        first.focus()
+      }
     })
 
     // Touch swipe navigation for mobile

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -44,4 +44,5 @@ const socialLinks = Object.entries(rawLinks)
     <slot />
   </main>
   <Footer />
+  <slot name="overlay" />
 </Base>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -78,7 +78,7 @@ const schema = websiteSchema(seo?.title ?? String(config.title), siteUrl, String
       <a href="/photography" class="cta-link">Browse collections &rarr;</a>
     </div>
   </section>
-  <PhotoLightbox photos={photos} />
+  <PhotoLightbox photos={photos} slot="overlay" />
 </Page>
 
 <style>

--- a/src/pages/photography/[slug].astro
+++ b/src/pages/photography/[slug].astro
@@ -116,7 +116,7 @@ const schema = {
 
     {photos.length > 0 && <PhotoGrid photos={photos} />}
   </section>
-  <PhotoLightbox photos={photos} />
+  <PhotoLightbox photos={photos} slot="overlay" />
 </Page>
 
 <style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -212,6 +212,13 @@ img {
   height: auto;
 }
 
+/* === Focus === */
+
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+}
+
 /* === Font Declarations === */
 
 @font-face {

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -12,6 +12,23 @@
   border-width: 0;
 }
 
+/* Reveal visually-hidden interactive elements (e.g. the skip link) on focus */
+.visually-hidden:focus-visible {
+  position: fixed;
+  top: var(--space-4);
+  left: var(--space-4);
+  z-index: 400;
+  width: auto;
+  height: auto;
+  padding: var(--space-2) var(--space-4);
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+}
+
 .container {
   width: 100%;
   max-width: var(--max-content);


### PR DESCRIPTION
Phase 1 of the [2026-08-02 design audit remediation plan](https://github.com/lukecartledge/portfolio) — the three P0s from the Impeccable audit, which share one root cause: **interactive things were built from non-interactive HTML.**

Before this PR, **the photographs could not be opened by keyboard, and the mobile nav could not be opened by keyboard** (both WCAG 2.1.1 Level A), and there was not one `:focus-visible` rule in the codebase.

## Commits

| Commit | What |
|---|---|
| `ea9ad8e` | Site-wide `:focus-visible` system + skip link revealed on focus |
| `e9288a6` | Photo card `<figure>` → `<button>` |
| `c2b3625` | Mobile nav `<label>` triggers → `<button aria-expanded aria-controls>` |
| `34b5c8a` | Render the lightbox in a named `overlay` slot (prerequisite for `inert`) |
| `5266498` | Lightbox dialog focus contract: capture, move, trap, `inert`, restore |

## Notes on approach

- **Photo cards need no JS change.** Keeping the `.photo-card` class on the new `<button>` means the existing click delegation is untouched, and Enter/Space now work natively. The overlay `<div>` became a `<span>` to keep the button's phrasing-content model valid.
- **The nav checkbox is retained as the state holder**, so every existing `:checked` CSS selector is unchanged — a small script toggles it and syncs `aria-expanded`/`aria-hidden`.
- **The lightbox had to move out of `<main>`** before background content could be marked `inert`, since `<main>` was also the dialog's ancestor. Purely structural; the lightbox is `position: fixed`.
- **Nav arrows are excluded from the focus trap** on viewports where they're `display: none` (below 640px), so Tab correctly parks on the single close button.

## ⚠️ Trade-off to confirm

The plan said to keep the checkbox "as a no-JS fallback". **The checkbox is kept, but the true no-JS path is gone** — with `<button>` triggers instead of `<label>`, nothing can toggle the checkbox without JS. Preserving both would need duplicated markup behind a `no-js` class.

I judged this acceptable because the gallery lightbox already hard-requires JS, and a keyboard-inaccessible nav is by far the worse defect. Say the word if you'd rather have the `no-js` fallback back.

## Verification

- ✅ `npm run lint` clean — 0 errors, 0 warnings (2 pre-existing hints in `Head.astro`, untouched)
- ✅ `npm run build` succeeds, all 8 pages
- ✅ Built HTML: 6/6 photo cards are `<button aria-label="View …">`; 0 `for="mobile-nav-toggle"` labels remain; lightbox renders after `</footer>` on both page templates
- ✅ All four `:focus-visible` rules present in the built CSS
- ⏳ **Not verified — needs a browser.** The plan's own checkpoint (tab through every page, confirm the focus trap and restore, open the nav at 375px, re-run axe) could not be run here. Worth doing before merge, which is why this is a draft.

## Out of scope

`Escape` to close the mobile nav isn't in the Phase 1 list, so it isn't here — the close button is keyboard-reachable. Flagging as a candidate follow-up.
